### PR TITLE
Patch for right determination of IPprefix if have more than one network interface.

### DIFF
--- a/LANs.py
+++ b/LANs.py
@@ -905,6 +905,9 @@ def main():
 	#Find the gateway and interface
 	ipr = Popen(['/sbin/ip', 'route'], stdout=PIPE, stderr=DN)
 	ipr = ipr.communicate()[0]
+	iprs = ipr.split('\n')
+	for route in range(1,len(iprs)):
+	    iprs[route]=iprs[route].split()
 	ipr = repr(ipr).split(' ')
 	routerIP = ipr[2]
 	IPprefix = ipr[8][2:]
@@ -912,7 +915,11 @@ def main():
 		interface = args.interface
 	else:
 		interface = ipr[4]
-
+        for ip in iprs:
+	    for i in ip:
+	        if i == interface:
+		    IPprefix=ip[0]
+		    break
 	if args.ipaddress:
 		victimIP = args.ipaddress
 	else:


### PR DESCRIPTION
Hello.
If you have more than one interfaces you have to properly search for IP prefix.
example my ip route output:
default via 192.168.10.1 dev eth1  proto static 
10.8.0.0/24 via 10.8.0.13 dev tun0 
10.8.0.13 dev tun0  proto kernel  scope link  src 10.8.0.14 
192.168.10.0/24 dev eth1  proto kernel  scope link  src 192.168.10.101  metric 9
so IPprefix = ipr[8][2:] is 10.8.0.0/24 but right is 192.168.10.0/24
this patch searching for interface in routes and give right IPprefix
