### PR TITLE
Fixed an issue with the 'ARP' scan and rDNS

### DIFF
--- a/LANs.py
+++ b/LANs.py
@@ -742,7 +742,7 @@ class active_users():
 		iplist = []
 		maclist = []
 		try:
-			nmap = Popen(['/usr/bin/nmap', '-sn', '-n' '192.168.1.*'], stdout=PIPE, stderr=DN)
+			nmap = Popen(['/usr/bin/nmap', '-sn', '-n', '192.168.1.*'], stdout=PIPE, stderr=DN)
 			nmap = nmap.communicate()[0]
 			nmap = nmap.splitlines()[2:-1]
 		except:


### PR DESCRIPTION
When performing the 'ARP' scan for local network members, if the
machine's DNS server has a reverse DNS entry for the router's IP
Nmap will automatically use that instead of the router's IP in its
output. Using the '-n' flag when calling Nmap avoids that issue.
