### PR TITLE
There are other local networks than 192.168.1.0/24

### DIFF
--- a/LANs.py
+++ b/LANs.py
@@ -742,7 +742,7 @@ class active_users():
 		iplist = []
 		maclist = []
 		try:
-			nmap = Popen(['/usr/bin/nmap', '-sn', '192.168.1.*'], stdout=PIPE, stderr=DN)
+			nmap = Popen(['/usr/bin/nmap', '-sn', IPprefix], stdout=PIPE, stderr=DN)
 			nmap = nmap.communicate()[0]
 			nmap = nmap.splitlines()[2:-1]
 		except:


### PR DESCRIPTION
This was good previously, but abfff7ce caused the local network prefix for nmap to scan to be statically set to '192.168.1.*'. Obviously there are other local networks used in the wild.
