### PR TITLE
docs: Fix a few typos

### DIFF
--- a/LANs.py
+++ b/LANs.py
@@ -1368,7 +1368,7 @@ def channel_hop(mon_iface, args):
 
             proc = Popen(['iw', 'dev', mon_iface, 'set', 'channel', monchannel], stdout=DN, stderr=PIPE)
             for line in proc.communicate()[1].split('\n'):
-                if len(line) > 2:  # iw dev shouldnt display output unless there's an error
+                if len(line) > 2:  # iw dev shouldn't display output unless there's an error
                     err = '[' + R + '-' + W + '] Channel hopping failed: ' + R + line + W
 
         output(err, monchannel)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I do not maintain this anymore. I highly suggest using bettercap instead for ARP
 * Automatically find the most active WLAN users then spy on one of them and/or inject arbitrary HTML/JS into pages they visit. 
     * Individually poisons the ARP tables of the target box, the router and the DNS server if necessary. Does not poison anyone else on the network. Displays all most the interesting bits of their traffic and can inject custom html into pages they visit. Cleans up after itself.
 
-* Also can be used to continuosly jam nearby WiFi networks. This has an approximate range of a 1 block radius, but this can vary based off of the strength of your WiFi card. This can be fine tuned to allow jamming of everyone or even just one client. (Cannot jam WiFi and spy simultaneously) 
+* Also can be used to continuously jam nearby WiFi networks. This has an approximate range of a 1 block radius, but this can vary based off of the strength of your WiFi card. This can be fine tuned to allow jamming of everyone or even just one client. (Cannot jam WiFi and spy simultaneously) 
 
 
 Prerequisites: Linux, python-scapy, python-nfqueue (nfqueue-bindings 0.4-3), aircrack-ng, python-twisted, BeEF (optional), nmap, nbtscan, and a wireless card capable of promiscuous mode if you choose not to use the -ip option
@@ -84,7 +84,7 @@ python LANs.py -a -r 80.87.128.67
 ``` shell
 python LANs.py -dns eff.org
 ```
-Example 1: The -a option will spoof every single DNS request the victim makes and when used in conjuction with -r it will redirect them to -r's argument address. The victim will be redirected to stallman.org (80.87.128.67) no matter what they type in the address bar.  
+Example 1: The -a option will spoof every single DNS request the victim makes and when used in conjunction with -r it will redirect them to -r's argument address. The victim will be redirected to stallman.org (80.87.128.67) no matter what they type in the address bar.  
 
 Example 2: This will spoof the domain eff.org and subdomains of eff.org. When there is no -r argument present with the -a or -dns arguments the script will default to sending the victim to the attacker's IP address. If the victim tries to go to eff.org they will be redirected to the attacker's IP.
 


### PR DESCRIPTION
There are small typos in:
- LANs.py
- README.md

Fixes:
- Should read `shouldn't` rather than `shouldnt`.
- Should read `continuously` rather than `continuosly`.
- Should read `conjunction` rather than `conjuction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md